### PR TITLE
remove spaces if more than 1

### DIFF
--- a/scripts/tools.ts
+++ b/scripts/tools.ts
@@ -38,6 +38,6 @@ export const parseSvg = (svg: string) => {
     .replace('shape-rendering="geometricPrecision"', '')
     .replace('width="24"', '')
     .replace('height="24"', '')
-  
+    .replace(/ +(?= )/g, '');
   return svg
 }


### PR DESCRIPTION
Small optimization: clean up spaces in generated components, removes spaces if more than single space encountered

Currently, there are 4 spaces in each `<svg ` tag generated by the builder